### PR TITLE
Replace deprecated method to new one

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -7,7 +7,7 @@ my $build = Module::Build->new(
   module_name  => 'Mojolicious::Plugin::Humane',
   dist_author  => 'Joel A. Berger <joel.a.berger@gmail.com>',
   requires     => {
-    'Mojolicious' => '3.00'
+    'Mojolicious' => '4.77'
   },
   configure_requires => {
     'Module::Build' => 0.38,

--- a/lib/Mojolicious/Plugin/Humane.pm
+++ b/lib/Mojolicious/Plugin/Humane.pm
@@ -97,7 +97,7 @@ sub register {
 
     my $append = $c->humane_include;
     $head->append_content( $append );
-    $c->tx->res->body( $dom->to_xml );
+    $c->tx->res->body( $dom->to_string );
   } ) if $conf{auto};
 
   return $plugin;


### PR DESCRIPTION
In [Mojolicious 4.77](https://github.com/kraih/mojo/commit/f44ad6868a456241f1cdf2a8ad272cad261da7a1) `to_xml()` method is deprecated and in [4.98](https://github.com/kraih/mojo/commit/fa0f23c11cc9dc92a9bbb3d5846cb0232bcc0c69) it was completely removed from source tree. So humane plugin cannot passed the test with Mojolicious 4.98.

This patch fixes the failed test `t/basic.t`. :)
